### PR TITLE
Fix bug with 'book' rhymes with 'k'

### DIFF
--- a/src/rhymes_with/rhymes.py
+++ b/src/rhymes_with/rhymes.py
@@ -4,6 +4,11 @@ def does_rhyme(word1: str, word2: str, length: int = 3) -> bool:
         same ending up to length.
     """
     length = min(3, len(word1), len(word2))
+
+    # 'k' does not rhyme with 'book'
+    if length == 1:
+        return word1 == word2
+
     return word1[-length:] == word2[-length:]
 
 

--- a/tests/test_rhymes.py
+++ b/tests/test_rhymes.py
@@ -3,3 +3,9 @@ from rhymes_with.rhymes import does_rhyme
 
 def test_cook_rhymes_with_book():
     assert does_rhyme("book", "cook")
+
+
+def test_fix_letter():
+    assert not does_rhyme("book", "k")
+    assert not does_rhyme("booc", "c")
+    assert does_rhyme("a", "a")


### PR DESCRIPTION
Due to a shortcoming of the current algorithm, the case where you have a
single letter, it would be listed as rhyming with every word ending on
that letter.

For example, 'book' `rhymes_with` 'k' even though "book" does in fact not
rhyme with "k".